### PR TITLE
Fix detectface empty check

### DIFF
--- a/src/detectface.py
+++ b/src/detectface.py
@@ -11,7 +11,7 @@ def detectface(img):
     )
     gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
     faces = face_cascade.detectMultiScale(gray, 1.3, 5)
-    if faces is ():
+    if faces is None or len(faces) == 0:
         return False
     for x, y, w, h in faces:
         roi_gray = img[y : y + h, x : x + w]

--- a/tests/test_detectface.py
+++ b/tests/test_detectface.py
@@ -1,0 +1,24 @@
+import os
+import unittest
+import numpy as np
+
+# Ensure src is on the path
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.detectface import detectface
+
+class DetectFaceNoFaceTest(unittest.TestCase):
+    def test_no_face_returns_false(self):
+        # Create a blank image with no faces
+        img = np.zeros((224, 224, 3), dtype=np.uint8)
+        # Change working directory so cascade path resolves
+        cwd = os.getcwd()
+        try:
+            os.chdir(os.path.join(cwd, 'restapi', 'memegen'))
+            self.assertFalse(detectface(img))
+        finally:
+            os.chdir(cwd)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix empty tuple comparison in `detectface`
- add a unit test ensuring `detectface` returns False when no face detected

## Testing
- `pytest -q tests/test_detectface.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684748a30034832f97c7178e85e31786